### PR TITLE
[TEST PR] fix(docs-infra): fix wrong `visibleLines` numbers in `docs-code` blocks (for v19)

### DIFF
--- a/adev/src/content/tutorials/first-app/steps/01-hello-world/README.md
+++ b/adev/src/content/tutorials/first-app/steps/01-hello-world/README.md
@@ -94,11 +94,11 @@ In your IDE:
 1. Next, open  `first-app/src/app/app.component.ts`.
 1. In `app.component.ts`, in the `@Component` definition, replace the `template` line with this code to change the text in the app component.
 
-    <docs-code header="Replace in src/app/app.component.ts" path="adev/src/content/tutorials/first-app/steps/02-HomeComponent/src/app/app.component.ts" visibleLines="[7,9]"/>
+    <docs-code header="Replace in src/app/app.component.ts" path="adev/src/content/tutorials/first-app/steps/02-HomeComponent/src/app/app.component.ts" visibleLines="[6,8]"/>
 
 1. In `app.component.ts`, in the `AppComponent` class definition, replace the `title` line with this code to change the component title.
 
-    <docs-code header="Replace in src/app/app.component.ts" path="adev/src/content/tutorials/first-app/steps/02-HomeComponent/src/app/app.component.ts" visibleLines="[12,14]"/>
+    <docs-code header="Replace in src/app/app.component.ts" path="adev/src/content/tutorials/first-app/steps/02-HomeComponent/src/app/app.component.ts" visibleLines="[11,13]"/>
 
     Then, save the changes you made to `app.component.ts`.
 

--- a/adev/src/content/tutorials/first-app/steps/02-HomeComponent/README.md
+++ b/adev/src/content/tutorials/first-app/steps/02-HomeComponent/README.md
@@ -70,11 +70,11 @@ In the **Edit** pane of your IDE:
 
 1. In `app.component.ts`, in `@Component`, update the `imports` array property and add `HomeComponent`.
 
-    <docs-code header="Replace in src/app/app.component.ts" path="adev/src/content/tutorials/first-app/steps/03-HousingLocation/src/app/app.component.ts" visibleLines="[7]"/>
+    <docs-code header="Replace in src/app/app.component.ts" path="adev/src/content/tutorials/first-app/steps/03-HousingLocation/src/app/app.component.ts" visibleLines="[6]"/>
 
 1. In `app.component.ts`, in `@Component`, update the `template` property to include the following HTML code.
 
-    <docs-code header="Replace in src/app/app.component.ts" path="adev/src/content/tutorials/first-app/steps/03-HousingLocation/src/app/app.component.ts" visibleLines="[8,17]"/>
+    <docs-code header="Replace in src/app/app.component.ts" path="adev/src/content/tutorials/first-app/steps/03-HousingLocation/src/app/app.component.ts" visibleLines="[7,16]"/>
 
 1. Save your changes to  `app.component.ts`.
 1. If `ng serve` is running, the app should update.
@@ -100,7 +100,7 @@ In the **Edit** pane of your IDE:
 1. In the `first-app` directory, open `home.component.ts` in the editor.
 1. In `home.component.ts`, in `@Component`, update the `template` property with this code.
 
-    <docs-code header="Replace in src/app/home/home.component.ts" path="adev/src/content/tutorials/first-app/steps/03-HousingLocation/src/app/home/home.component.ts" visibleLines="[8,15]"/>
+    <docs-code header="Replace in src/app/home/home.component.ts" path="adev/src/content/tutorials/first-app/steps/03-HousingLocation/src/app/home/home.component.ts" visibleLines="[7,14]"/>
 
 1. Next, open `home.component.css` in the editor and update the content with these styles.
 

--- a/adev/src/content/tutorials/first-app/steps/03-HousingLocation/README.md
+++ b/adev/src/content/tutorials/first-app/steps/03-HousingLocation/README.md
@@ -51,11 +51,11 @@ In the **Edit** pane of your IDE:
 
 1. Next update the `imports` property of the `@Component` metadata by adding `HousingLocationComponent` to the array.
 
-    <docs-code header="Add HousingLocationComponent to imports array in src/app/home/home.component.ts" path="adev/src/content/tutorials/first-app/steps/04-interfaces/src/app/home/home.component.ts" visibleLines="[7]"/>
+    <docs-code header="Add HousingLocationComponent to imports array in src/app/home/home.component.ts" path="adev/src/content/tutorials/first-app/steps/04-interfaces/src/app/home/home.component.ts" visibleLines="[6]"/>
 
 1. Now the component is ready for use in the template for the `HomeComponent`. Update the `template` property of the `@Component` metadata to include a reference to the `<app-housing-location>` tag.
 
-    <docs-code header="Add housing location to the component template in src/app/home/home.component.ts" path="adev/src/content/tutorials/first-app/steps/04-interfaces/src/app/home/home.component.ts" visibleLines="[8,18]"/>
+    <docs-code header="Add housing location to the component template in src/app/home/home.component.ts" path="adev/src/content/tutorials/first-app/steps/04-interfaces/src/app/home/home.component.ts" visibleLines="[7,17]"/>
 
 </docs-step>
 

--- a/adev/src/content/tutorials/first-app/steps/04-interfaces/README.md
+++ b/adev/src/content/tutorials/first-app/steps/04-interfaces/README.md
@@ -70,7 +70,7 @@ There are a few more lessons to complete before that happens.
 
 1. In `src/app/home/home.component.ts`, replace the empty `export class HomeComponent {}` definition with this code to create a single instance of the new interface in the component.
 
-    <docs-code header="Add sample data to src/app/home/home.component.ts" path="adev/src/content/tutorials/first-app/steps/05-inputs/src/app/home/home.component.ts" visibleLines="[23,36]"/>
+    <docs-code header="Add sample data to src/app/home/home.component.ts" path="adev/src/content/tutorials/first-app/steps/05-inputs/src/app/home/home.component.ts" visibleLines="[22,35]"/>
 
 1. Confirm that your `home.component.ts` file matches like this example.
 

--- a/adev/src/content/tutorials/first-app/steps/05-inputs/README.md
+++ b/adev/src/content/tutorials/first-app/steps/05-inputs/README.md
@@ -33,7 +33,7 @@ In the code editor:
 <docs-step title="Add the Input property">
 1.  In the same file, add a property called `housingLocation` of type `HousingLocation` to the `HousingLocationComponent` class. Add an `!` after the property name and prefix it with the `@Input()` decorator:
 
-    <docs-code header="Import HousingLocationComponent and Input in src/app/housing-location/housing-location.component.ts" path="adev/src/content/tutorials/first-app/steps/06-property-binding/src/app/housing-location/housing-location.component.ts" visibleLines="[13,15]"/>
+    <docs-code header="Add housingLocation property to HousingLocationComponent in src/app/housing-location/housing-location.component.ts" path="adev/src/content/tutorials/first-app/steps/06-property-binding/src/app/housing-location/housing-location.component.ts" visibleLines="[12,14]"/>
 
     You have to add the `!` because the input is expecting the value to be passed. In this case, there is no default value. In our example application case we know that the value will be passed in - this is by design. The exclamation point is called the non-null assertion operator and it tells the TypeScript compiler that the value of this property won't be null or undefined.
 

--- a/adev/src/content/tutorials/first-app/steps/06-property-binding/README.md
+++ b/adev/src/content/tutorials/first-app/steps/06-property-binding/README.md
@@ -26,7 +26,7 @@ In the code editor:
 
 1. Navigate to `src/app/home/home.component.ts`
 1. In the template property of the `@Component` decorator, update the code to match the code below:
-    <docs-code header="Add housingLocation property binding" path="adev/src/content/tutorials/first-app/steps/07-dynamic-template-values/src/app/home/home.component.ts" visibleLines="[17,19]"/>
+    <docs-code header="Add housingLocation property binding" path="adev/src/content/tutorials/first-app/steps/07-dynamic-template-values/src/app/home/home.component.ts" visibleLines="[16,18]"/>
 
     When adding a property binding to a component tag, we use the `[attribute] = "value"` syntax to notify Angular that the assigned value should be treated as a property from the component class and not a string value.
 

--- a/adev/src/content/tutorials/first-app/steps/07-dynamic-template-values/README.md
+++ b/adev/src/content/tutorials/first-app/steps/07-dynamic-template-values/README.md
@@ -27,7 +27,7 @@ In the code editor:
 1.  Navigate to `src/app/housing-location/housing-location.component.ts`
 1.  In the template property of the `@Component` decorator, replace the existing HTML markup with the following code:
 
-<docs-code header="Update HousingLocationComponent template" path="adev/src/content/tutorials/first-app/steps/08-ngFor/src/app/housing-location/housing-location.component.ts" visibleLines="[9,20]"/>
+<docs-code header="Update HousingLocationComponent template" path="adev/src/content/tutorials/first-app/steps/08-ngFor/src/app/housing-location/housing-location.component.ts" visibleLines="[8,19]"/>
 
   In this updated template code you have used property binding to bind the `housingLocation.photo` to the `src` attribute. The `alt` attribute uses interpolation to give more context to the alt text of the image.
 

--- a/adev/src/content/tutorials/first-app/steps/08-ngFor/README.md
+++ b/adev/src/content/tutorials/first-app/steps/08-ngFor/README.md
@@ -35,11 +35,11 @@ In the `HomeComponent` there is only a single housing location. In this step, yo
 Now the app has a dataset that you can use to display the entries in the browser using the `ngFor` directive.
 
 1. Update the `<app-housing-location>` tag in the template code to this:
-    <docs-code header="Add ngFor to HomeComponent template" path="adev/src/content/tutorials/first-app/steps/09-services/src/app/home/home.component.ts" visibleLines="[17,22]"/>
+    <docs-code header="Add ngFor to HomeComponent template" path="adev/src/content/tutorials/first-app/steps/09-services/src/app/home/home.component.ts" visibleLines="[17,20]"/>
 
     Note, in the code `[housingLocation] = "housingLocation"` the `housingLocation` value now refers to the variable used in the `ngFor` directive. Before this change, it referred to the property on the `HomeComponent` class.
 
-    IMPORTANT: Don't forget to import the `NgFor` directive in your `HomeComponent` class.
+   IMPORTANT: Don't forget to import the `NgFor` directive in your `HomeComponent` class.
 
 1. Save all changes.
 

--- a/adev/src/content/tutorials/first-app/steps/09-services/README.md
+++ b/adev/src/content/tutorials/first-app/steps/09-services/README.md
@@ -51,9 +51,9 @@ For now, your app's new service uses the data that has, so far, been created loc
 
 In the **Edit** pane of your IDE:
 
-1. In `src/app/home/home.component.ts`, from `HomeComponent`, copy the `housingLocationList` variable and its array value.
+1. In `src/app/home/home.component.ts`, from `HomeComponent`, copy the `housingLocationList` property and its array value, as well as the   `baseUrl` property.
 1. In `src/app/housing.service.ts`:
-    1. Inside the `HousingService` class, paste the variable that you copied from `HomeComponent` in the previous step.
+    1. Inside the `HousingService` class, paste the properties that you copied from `HomeComponent` in the previous step.
     1. Inside the `HousingService` class, paste these functions after the data you just copied.
         These functions allow dependencies to access the service's data.
 

--- a/adev/src/content/tutorials/first-app/steps/10-routing/README.md
+++ b/adev/src/content/tutorials/first-app/steps/10-routing/README.md
@@ -49,11 +49,11 @@ In this lesson, you will enable routing in your application to navigate to the d
 
     1. Add `RouterModule` to the `@Component` metadata imports
 
-        <docs-code header="Import RouterModule in src/app/app.component.ts" path="adev/src/content/tutorials/first-app/steps/11-details-page/src/app/app.component.ts" visibleLines="[7]"/>
+        <docs-code header="Import RouterModule in src/app/app.component.ts" path="adev/src/content/tutorials/first-app/steps/11-details-page/src/app/app.component.ts" visibleLines="[6]"/>
 
     1. In the `template` property, replace the `<app-home></app-home>` tag with the `<router-outlet>` directive and add a link back to the home page. Your code should match this code:
 
-        <docs-code header="Add router-outlet in src/app/app.component.ts" path="adev/src/content/tutorials/first-app/steps/11-details-page/src/app/app.component.ts" visibleLines="[8,18]"/>
+        <docs-code header="Add router-outlet in src/app/app.component.ts" path="adev/src/content/tutorials/first-app/steps/11-details-page/src/app/app.component.ts" visibleLines="[7,18]"/>
 
 </docs-step>
 

--- a/adev/src/content/tutorials/first-app/steps/11-details-page/README.md
+++ b/adev/src/content/tutorials/first-app/steps/11-details-page/README.md
@@ -29,7 +29,7 @@ In this case, `:id` is dynamic and will change based on how the route is request
 
 1. In `src/app/housing-location/housing-location.component.ts`, add an anchor tag to the `section` element and include the `routerLink` directive:
 
-    <docs-code header="Add anchor with a routerLink directive to housing-location.component.ts" path="adev/src/content/tutorials/first-app/steps/12-forms/src/app/housing-location/housing-location.component.ts" visibleLines="[20]"/>
+    <docs-code header="Add anchor with a routerLink directive to housing-location.component.ts" path="adev/src/content/tutorials/first-app/steps/12-forms/src/app/housing-location/housing-location.component.ts" visibleLines="[19]"/>
 
     The `routerLink` directive enables Angular's router to create dynamic links in the application. The value assigned to the `routerLink` is an array with two entries: the static portion of the path and the dynamic data.
 
@@ -56,13 +56,13 @@ In this step, you will get the route parameter in the `DetailsComponent`. Curren
 1. Update the body of the `DetailsComponent` class with the following code:
 
     <docs-code language="javascript">
-        export class DetailsComponent {
-            route: ActivatedRoute = inject(ActivatedRoute);
-            housingLocationId = -1;
-            constructor() {
-                this.housingLocationId = Number(this.route.snapshot.params['id']);
-            }
-        }
+    export class DetailsComponent {
+      route: ActivatedRoute = inject(ActivatedRoute);
+      housingLocationId = -1;
+      constructor() {
+        this.housingLocationId = Number(this.route.snapshot.params['id']);
+      }
+    }
     </docs-code>
 
     This code gives the `DetailsComponent` access to the `ActivatedRoute` router feature that enables you to have access to the data about the current route. In the `constructor`, the code converts the `id` parameter acquired from the route from a string to a number.
@@ -72,20 +72,20 @@ In this step, you will get the route parameter in the `DetailsComponent`. Curren
 1. In the browser, click on one of the housing location's "Learn More" links and confirm that the numeric value displayed on the page matches the `id` property for that location in the data.
 </docs-step>
 
-<docs-step title="Customize the `DetailComponent`">
+<docs-step title="Customize the `DetailsComponent`">
 Now that routing is working properly in the application this is a great time to update the template of the `DetailsComponent` to display the specific data represented by the housing location for the route parameter.
 
 To access the data you will add a call to the `HousingService`.
 
 1. Update the template code to match the following code:
 
-    <docs-code header="Update the DetailsComponent template in src/app/details/details.component.ts" path="adev/src/content/tutorials/first-app/steps/12-forms/src/app/details/details.component.ts" visibleLines="[11,32]"/>
+    <docs-code header="Update the DetailsComponent template in src/app/details/details.component.ts" path="adev/src/content/tutorials/first-app/steps/12-forms/src/app/details/details.component.ts" visibleLines="[10,31]"/>
 
     Notice that the `housingLocation` properties are being accessed with the optional chaining operator `?`. This ensures that if the `housingLocation` value is null or undefined the application doesn't crash.
 
 1. Update the body of the `DetailsComponent` class to match the following code:
 
-    <docs-code header="Update the DetailsComponent class in src/app/details/details.component.ts" path="adev/src/content/tutorials/first-app/steps/12-forms/src/app/details/details.component.ts" visibleLines="[35,44]"/>
+    <docs-code header="Update the DetailsComponent class in src/app/details/details.component.ts" path="adev/src/content/tutorials/first-app/steps/12-forms/src/app/details/details.component.ts" visibleLines="[34,43]"/>
 
     Now the component has the code to display the correct information based on the selected housing location. The `constructor` now includes a call to the `HousingService` to pass the route parameter as an argument to the `getHousingLocationById` service function.
 
@@ -93,7 +93,12 @@ To access the data you will add a call to the `HousingService`.
 
     <docs-code header="Add styles for the DetailsComponent" path="adev/src/content/tutorials/first-app/steps/12-forms/src/app/details/details.component.css" visibleLines="[1,71]"/>
 
-1. Save your changes.
+    and save your changes
+
+1. In `DetailsComponent` use the just created `details.component.css` file as the source for the styles: 
+    <docs-code header="Update details.component.ts to use the created css file" path="adev/src/content/tutorials/first-app/steps/12-forms/src/app/details/details.component.ts" visibleLines="[32]"/>
+
+
 
 1. In the browser refresh the page and confirm that when you click on the "Learn More" link for a given housing location the details page displays the correct information based on the data for that selected item.
 
@@ -101,14 +106,14 @@ To access the data you will add a call to the `HousingService`.
 
 </docs-step>
 
-<docs-step title="Add navigation to the `HomeComponent`">
+<docs-step title="Check navigation in the `HomeComponent`">
 In a previous lesson you updated the `AppComponent` template to include a `routerLink`. Adding that code updated your app to enable navigation back to the `HomeComponent` whenever the logo is clicked.
 
 1. Confirm that your code matches the following:
 
-    <docs-code header="Add routerLink to AppComponent" path="adev/src/content/tutorials/first-app/steps/12-forms/src/app/app.component.ts" visibleLines="[8,20]"/>
+    <docs-code header="Make sure the routerLink is used within AppComponent" path="adev/src/content/tutorials/first-app/steps/12-forms/src/app/app.component.ts" visibleLines="[8,20]"/>
 
-    Your code may already be up-to-date but confirm to be sure.
+    Your code should already be up-to-date but confirm to be sure.
 </docs-step>
 
 </docs-workflow>

--- a/adev/src/content/tutorials/first-app/steps/12-forms/README.md
+++ b/adev/src/content/tutorials/first-app/steps/12-forms/README.md
@@ -25,7 +25,7 @@ In the **Edit** pane of your IDE:
 
 1. In `src/app/housing.service.ts`, inside the `HousingService` class, paste this method at the bottom of the class definition.
 
-<docs-code header="Submit method in src/app/housing.service.ts" path="adev/src/content/tutorials/first-app/steps/13-search/src/app/housing.service.ts" visibleLines="[120,124]"/>
+    <docs-code header="Submit method in src/app/housing.service.ts" path="adev/src/content/tutorials/first-app/steps/13-search/src/app/housing.service.ts" visibleLines="[120,124]"/>
 
 1. Confirm that the app builds without error.
    Correct any errors before you continue to the next step.
@@ -38,21 +38,21 @@ In the **Edit** pane of your IDE, in `src/app/details/details.component.ts`:
 
 1. After the `import` statements at the top of the file, add the following code to import the Angular form classes.
 
-<docs-code header="Forms imports in src/app/details/details.component.ts" path="adev/src/content/tutorials/first-app/steps/13-search/src/app/details/details.component.ts" visibleLines="[6]"/>
+    <docs-code header="Forms imports in src/app/details/details.component.ts" path="adev/src/content/tutorials/first-app/steps/13-search/src/app/details/details.component.ts" visibleLines="[6]"/>
 
 1. In the `DetailsComponent` decorator metadata, update the `imports` property with the following code:
 
-<docs-code header="imports directive in src/app/details/details.component.ts" path="adev/src/content/tutorials/first-app/steps/13-search/src/app/details/details.component.ts" visibleLines="[10]"/>
+    <docs-code header="imports directive in src/app/details/details.component.ts" path="adev/src/content/tutorials/first-app/steps/13-search/src/app/details/details.component.ts" visibleLines="[9]"/>
 
 1. In the `DetailsComponent` class, before the `constructor()` method, add the following code to create the form object.
 
-   <docs-code header="template directive in src/app/details/details.component.ts" path="adev/src/content/tutorials/first-app/steps/13-search/src/app/details/details.component.ts" visibleLines="[53,57]"/>
+   <docs-code header="template directive in src/app/details/details.component.ts" path="adev/src/content/tutorials/first-app/steps/13-search/src/app/details/details.component.ts" visibleLines="[52,56]"/>
 
    In Angular, `FormGroup` and `FormControl` are types that enable you to build forms. The `FormControl` type can provide a default value and shape the form data. In this example `firstName` is a `string` and the default value is empty string.
 
 1. In the `DetailsComponent` class, after the `constructor()` method, add the following code to handle the **Apply now** click.
 
-   <docs-code header="template directive in src/app/details/details.component.ts" path="adev/src/content/tutorials/first-app/steps/13-search/src/app/details/details.component.ts" visibleLines="[63,69]"/>
+   <docs-code header="template directive in src/app/details/details.component.ts" path="adev/src/content/tutorials/first-app/steps/13-search/src/app/details/details.component.ts" visibleLines="[62,68]"/>
 
    This button does not exist yet - you will add it in the next step. In the above code, the `FormControl`s may return `null`. This code uses the nullish coalescing operator to default to empty string if the value is `null`.
 
@@ -67,7 +67,7 @@ In the **Edit** pane of your IDE, in `src/app/details/details.component.ts`:
 
 1. In the `DetailsComponent` decorator metadata, update the `template` HTML to match the following code to add the form's markup.
 
-   <docs-code header="template directive in src/app/details/details.component.ts" path="adev/src/content/tutorials/first-app/steps/13-search/src/app/details/details.component.ts" visibleLines="[11,46]"/>
+   <docs-code header="template directive in src/app/details/details.component.ts" path="adev/src/content/tutorials/first-app/steps/13-search/src/app/details/details.component.ts" visibleLines="[10,45]"/>
 
    The template now includes an event handler `(submit)="submitApplication()"`. Angular uses parentheses syntax around the event name to define events in the template code. The code on the right hand side of the equals sign is the code that should be executed when this event is triggered. You can bind to browser events and custom events.
 

--- a/adev/src/content/tutorials/first-app/steps/13-search/README.md
+++ b/adev/src/content/tutorials/first-app/steps/13-search/README.md
@@ -20,13 +20,13 @@ In this step, you'll update the `HomeComponent` class to store data in a new arr
 
 1. In `src/app/home/home.component.ts`, add new property to the class called `filteredLocationList`.
 
-   <docs-code header="Add the filtered results property" path="adev/src/content/tutorials/first-app/steps/14-http/src/app/home/home.component.ts" visibleLines="[30]"/>
+   <docs-code header="Add the filtered results property" path="adev/src/content/tutorials/first-app/steps/14-http/src/app/home/home.component.ts" visibleLines="[29]"/>
 
    The `filteredLocationList` hold the values that match the search criteria entered by the user.
 
 1. The `filteredLocationList` should contain the total set of housing locations values by default when the page loads. Update the `constructor` for the `HomeComponent` to set the value.
 
-<docs-code header="Set the value of filteredLocationList" path="adev/src/content/tutorials/first-app/steps/14-http/src/app/home/home.component.ts" visibleLines="[31,34]"/>
+   <docs-code header="Set the value of filteredLocationList" path="adev/src/content/tutorials/first-app/steps/14-http/src/app/home/home.component.ts" visibleLines="[30,33]"/>
 
 </docs-step>
 
@@ -35,25 +35,19 @@ The `HomeComponent` already contains an input field that you will use to capture
 
 1. Update the `HomeComponent` template to include a template variable in the `input` element called `#filter`.
 
-   <docs-code header="Add a template variable to HomeComponent's template" language="html">
-       <input type="text" placeholder="Filter by city" #filter>
-   </docs-code>
+   <docs-code header="Add a template variable to HomeComponent's template" path="adev/src/content/tutorials/first-app/steps/14-http/src/app/home/home.component.ts" visibleLines="[13]"/>
 
    This example uses a [template reference variable](guide/templates) to get access to the `input` element as its value.
 
 1. Next, update the component template to attach an event handler to the "Search" button.
 
-   <docs-code header="Bind the click event" language="html">
-       <button class="primary" type="button" (click)="filterResults(filter.value)">Search</button>
-   </docs-code>
+   <docs-code header="Bind the click event" path="adev/src/content/tutorials/first-app/steps/14-http/src/app/home/home.component.ts" visibleLines="[14]"/>
 
    By binding to the `click` event on the `button` element, you are able to call the `filterResults` function. The argument to the function is the `value` property of the `filter` template variable. Specifically, the `.value` property from the `input` HTML element.
 
 1. The last template update is to the `ngFor` directive. Update the `ngFor` value to iterate over values from the `filteredLocationList` array.
 
-<docs-code header="Update the ngFor directive value" language="html">
-    <app-housing-location *ngFor="let housingLocation of filteredLocationList" [housingLocation]="housingLocation"></app-housing-location>
-</docs-code>
+   <docs-code header="Update the ngFor directive value" path="adev/src/content/tutorials/first-app/steps/14-http/src/app/home/home.component.ts" visibleLines="[18,21]"/>
 
 </docs-step>
 
@@ -62,7 +56,7 @@ The template has been updated to bind the `filterResults` function to the `click
 
 1. Update the `HomeComponent` class to include the implementation of the `filterResults` function.
 
-   <docs-code header="Add the filterResults function implementation" path="adev/src/content/tutorials/first-app/steps/14-http/src/app/home/home.component.ts" visibleLines="[35,44]"/>
+   <docs-code header="Add the filterResults function implementation" path="adev/src/content/tutorials/first-app/steps/14-http/src/app/home/home.component.ts" visibleLines="[34,43]"/>
 
    This function uses the `String` `filter` function to compare the value of the `text` parameter against the `housingLocation.city` property. You can update this function to match against any property or multiple properties for a fun exercise.
 

--- a/adev/src/content/tutorials/first-app/steps/14-http/README.md
+++ b/adev/src/content/tutorials/first-app/steps/14-http/README.md
@@ -26,110 +26,110 @@ JSON Server is an open source tool used to create mock REST APIs. You'll use it 
 
 1. Open `db.json` and copy the following code into the file
     <docs-code language="json">
+    {
+      "locations": [
         {
-            "locations": [
-                {
-                    "id": 0,
-                    "name": "Acme Fresh Start Housing",
-                    "city": "Chicago",
-                    "state": "IL",
-                    "photo": "https://angular.dev/assets/images/tutorials/common/bernard-hermant-CLKGGwIBTaY-unsplash.jpg",
-                    "availableUnits": 4,
-                    "wifi": true,
-                    "laundry": true
-                },
-                {
-                    "id": 1,
-                    "name": "A113 Transitional Housing",
-                    "city": "Santa Monica",
-                    "state": "CA",
-                    "photo": "https://angular.dev/assets/images/tutorials/common/brandon-griggs-wR11KBaB86U-unsplash.jpg",
-                    "availableUnits": 0,
-                    "wifi": false,
-                    "laundry": true
-                },
-                {
-                    "id": 2,
-                    "name": "Warm Beds Housing Support",
-                    "city": "Juneau",
-                    "state": "AK",
-                    "photo": "https://angular.dev/assets/images/tutorials/common/i-do-nothing-but-love-lAyXdl1-Wmc-unsplash.jpg",
-                    "availableUnits": 1,
-                    "wifi": false,
-                    "laundry": false
-                },
-                {
-                    "id": 3,
-                    "name": "Homesteady Housing",
-                    "city": "Chicago",
-                    "state": "IL",
-                    "photo": "https://angular.dev/assets/images/tutorials/common/ian-macdonald-W8z6aiwfi1E-unsplash.jpg",
-                    "availableUnits": 1,
-                    "wifi": true,
-                    "laundry": false
-                },
-                {
-                    "id": 4,
-                    "name": "Happy Homes Group",
-                    "city": "Gary",
-                    "state": "IN",
-                    "photo": "https://angular.dev/assets/images/tutorials/common/krzysztof-hepner-978RAXoXnH4-unsplash.jpg",
-                    "availableUnits": 1,
-                    "wifi": true,
-                    "laundry": false
-                },
-                {
-                    "id": 5,
-                    "name": "Hopeful Apartment Group",
-                    "city": "Oakland",
-                    "state": "CA",
-                    "photo": "https://angular.dev/assets/images/tutorials/common/r-architecture-JvQ0Q5IkeMM-unsplash.jpg",
-                    "availableUnits": 2,
-                    "wifi": true,
-                    "laundry": true
-                },
-                {
-                    "id": 6,
-                    "name": "Seriously Safe Towns",
-                    "city": "Oakland",
-                    "state": "CA",
-                    "photo": "https://angular.dev/assets/images/tutorials/common/phil-hearing-IYfp2Ixe9nM-unsplash.jpg",
-                    "availableUnits": 5,
-                    "wifi": true,
-                    "laundry": true
-                },
-                {
-                    "id": 7,
-                    "name": "Hopeful Housing Solutions",
-                    "city": "Oakland",
-                    "state": "CA",
-                    "photo": "https://angular.dev/assets/images/tutorials/common/r-architecture-GGupkreKwxA-unsplash.jpg",
-                    "availableUnits": 2,
-                    "wifi": true,
-                    "laundry": true
-                },
-                {
-                    "id": 8,
-                    "name": "Seriously Safe Towns",
-                    "city": "Oakland",
-                    "state": "CA",
-                    "photo": "https://angular.dev/assets/images/tutorials/common/saru-robert-9rP3mxf8qWI-unsplash.jpg",
-                    "availableUnits": 10,
-                    "wifi": false,
-                    "laundry": false
-                },
-                {
-                    "id": 9,
-                    "name": "Capital Safe Towns",
-                    "city": "Portland",
-                    "state": "OR",
-                    "photo": "https://angular.dev/assets/images/tutorials/common/webaliser-_TPTXZd9mOo-unsplash.jpg",
-                    "availableUnits": 6,
-                    "wifi": true,
-                    "laundry": true
-                }
-            ]
+          "id": 0,
+          "name": "Acme Fresh Start Housing",
+          "city": "Chicago",
+          "state": "IL",
+          "photo": "https://angular.dev/assets/images/tutorials/common/bernard-hermant-CLKGGwIBTaY-unsplash.jpg",
+          "availableUnits": 4,
+          "wifi": true,
+          "laundry": true
+        },
+        {
+          "id": 1,
+          "name": "A113 Transitional Housing",
+          "city": "Santa Monica",
+          "state": "CA",
+          "photo": "https://angular.dev/assets/images/tutorials/common/brandon-griggs-wR11KBaB86U-unsplash.jpg",
+          "availableUnits": 0,
+          "wifi": false,
+          "laundry": true
+        },
+        {
+          "id": 2,
+          "name": "Warm Beds Housing Support",
+          "city": "Juneau",
+          "state": "AK",
+          "photo": "https://angular.dev/assets/images/tutorials/common/i-do-nothing-but-love-lAyXdl1-Wmc-unsplash.jpg",
+          "availableUnits": 1,
+          "wifi": false,
+          "laundry": false
+        },
+        {
+          "id": 3,
+          "name": "Homesteady Housing",
+          "city": "Chicago",
+          "state": "IL",
+          "photo": "https://angular.dev/assets/images/tutorials/common/ian-macdonald-W8z6aiwfi1E-unsplash.jpg",
+          "availableUnits": 1,
+          "wifi": true,
+          "laundry": false
+        },
+        {
+          "id": 4,
+          "name": "Happy Homes Group",
+          "city": "Gary",
+          "state": "IN",
+          "photo": "https://angular.dev/assets/images/tutorials/common/krzysztof-hepner-978RAXoXnH4-unsplash.jpg",
+          "availableUnits": 1,
+          "wifi": true,
+          "laundry": false
+        },
+        {
+          "id": 5,
+          "name": "Hopeful Apartment Group",
+          "city": "Oakland",
+          "state": "CA",
+          "photo": "https://angular.dev/assets/images/tutorials/common/r-architecture-JvQ0Q5IkeMM-unsplash.jpg",
+          "availableUnits": 2,
+          "wifi": true,
+          "laundry": true
+        },
+        {
+          "id": 6,
+          "name": "Seriously Safe Towns",
+          "city": "Oakland",
+          "state": "CA",
+          "photo": "https://angular.dev/assets/images/tutorials/common/phil-hearing-IYfp2Ixe9nM-unsplash.jpg",
+          "availableUnits": 5,
+          "wifi": true,
+          "laundry": true
+        },
+        {
+          "id": 7,
+          "name": "Hopeful Housing Solutions",
+          "city": "Oakland",
+          "state": "CA",
+          "photo": "https://angular.dev/assets/images/tutorials/common/r-architecture-GGupkreKwxA-unsplash.jpg",
+          "availableUnits": 2,
+          "wifi": true,
+          "laundry": true
+        },
+        {
+          "id": 8,
+          "name": "Seriously Safe Towns",
+          "city": "Oakland",
+          "state": "CA",
+          "photo": "https://angular.dev/assets/images/tutorials/common/saru-robert-9rP3mxf8qWI-unsplash.jpg",
+          "availableUnits": 10,
+          "wifi": false,
+          "laundry": false
+        },
+        {
+          "id": 9,
+          "name": "Capital Safe Towns",
+          "city": "Portland",
+          "state": "OR",
+          "photo": "https://angular.dev/assets/images/tutorials/common/webaliser-_TPTXZd9mOo-unsplash.jpg",
+          "availableUnits": 6,
+          "wifi": true,
+          "laundry": true
         }
+      ]
+    }
     </docs-code>
 
 1. Save this file.
@@ -150,33 +150,31 @@ The data source has been configured, the next step is to update your web app to 
 
 1. In `src/app/housing.service.ts`, make the following changes:
 
-    1. Update the code to remove `housingLocationList` property and the array containing the data.
+1. Update the code to remove `housingLocationList` property and the array containing the data, as well as the `baseUrl` property.
 
-    1. Add a string property called `url` and set its value to `'http://localhost:3000/locations'`
+1. Add a string property called `url` and set its value to `'http://localhost:3000/locations'`
 
-        <docs-code language="javascript">
-        url = 'http://localhost:3000/locations';
-        </docs-code>
+    <docs-code header="Add url property to housing.service.ts" path="adev/src/content/tutorials/first-app/steps/14-http/src-final/app/housing.service.ts" visibleLines="[8]"/>
 
-        This code will result in errors in the rest of the file because it depends on the `housingLocationList` property. We're going to update the service methods next.
+    This code will result in errors in the rest of the file because it depends on the `housingLocationList` property. We're going to update the service methods next.
 
-    1. Update the `getAllHousingLocations` function to make a call to the web server you configured.
+1. Update the `getAllHousingLocations` function to make a call to the web server you configured.
 
-        <docs-code header="" path="adev/src/content/tutorials/first-app/steps/14-http/src-final/app/housing.service.ts" visibleLines="[10,13]"/>
+    <docs-code header="Update the getAllHousingLocations method in housing.service.ts" path="adev/src/content/tutorials/first-app/steps/14-http/src-final/app/housing.service.ts" visibleLines="[10,13]"/>
 
-        The code now uses asynchronous code to make a **GET** request over HTTP.
+    The code now uses asynchronous code to make a **GET** request over HTTP.
 
-        HELPFUL: For this example, the code uses `fetch`. For more advanced use cases consider using `HttpClient` provided by Angular.
+    HELPFUL: For this example, the code uses `fetch`. For more advanced use cases consider using `HttpClient` provided by Angular.
 
-    1. Update the `getHousingLocationsById` function to make a call to the web server you configured.
-  
-       HELPFUL: Notice the `fetch` method has been updated to _query_ the data for location with a matching `id` property value. See [URL Search Parameter](https://developer.mozilla.org/en-US/docs/Web/API/URL/search) for more information.
+1. Update the `getHousingLocationsById` function to make a call to the web server you configured.
 
-        <docs-code header="" path="adev/src/content/tutorials/first-app/steps/14-http/src-final/app/housing.service.ts" visibleLines="[15,18]"/>
+    HELPFUL: Notice the `fetch` method has been updated to _query_ the data for location with a matching `id` property value. See [URL Search Parameter](https://developer.mozilla.org/en-US/docs/Web/API/URL/search) for more information.
 
-    1. Once all the updates are complete, your updated service should match the following code.
+    <docs-code header="Update the getHousingLocationById method in housing.service.ts" path="adev/src/content/tutorials/first-app/steps/14-http/src-final/app/housing.service.ts" visibleLines="[15,19]"/>
 
-        <docs-code header="Final version of housing.service.ts" path="adev/src/content/tutorials/first-app/steps/14-http/src-final/app/housing.service.ts" visibleLines="[1,24]" />
+1. Once all the updates are complete, your updated service should match the following code.
+
+    <docs-code header="Final version of housing.service.ts" path="adev/src/content/tutorials/first-app/steps/14-http/src-final/app/housing.service.ts" visibleLines="[1,24]" />
 
 </docs-step>
 
@@ -185,11 +183,11 @@ The server is now reading data from the HTTP request but the components that rel
 
 1. In `src/app/home/home.component.ts`, update the `constructor` to use the new asynchronous version of the `getAllHousingLocations` method.
 
-    <docs-code header="" path="adev/src/content/tutorials/first-app/steps/14-http/src-final/app/home/home.component.ts" visibleLines="[32,37]"/>
+    <docs-code header="Update constructor in home.component.ts" path="adev/src/content/tutorials/first-app/steps/14-http/src-final/app/home/home.component.ts" visibleLines="[31,36]"/>
 
 1. In `src/app/details/details.component.ts`, update the `constructor` to use the new asynchronous version of the `getHousingLocationById` method.
 
-    <docs-code header="" path="adev/src/content/tutorials/first-app/steps/14-http/src-final/app/details/details.component.ts" visibleLines="[61,66]"/>
+    <docs-code header="Update constructor in details.component.ts" path="adev/src/content/tutorials/first-app/steps/14-http/src-final/app/details/details.component.ts" visibleLines="[60,65]"/>
 
 1. Save your code.
 

--- a/adev/src/content/tutorials/learn-angular/steps/11-optimizing-images/README.md
+++ b/adev/src/content/tutorials/learn-angular/steps/11-optimizing-images/README.md
@@ -35,7 +35,8 @@ To enable the `NgOptimizedImage` directive, swap out the `src` attribute for `ng
 import { NgOptimizedImage } from '@angular/common';
 
 @Component({
-template: `     ...
+  template: `
+    ...
     <li>
       Static Image:
       <img ngSrc="/assets/logo.svg" alt="Angular logo" width="32" height="32" />
@@ -46,7 +47,7 @@ template: `     ...
     </li>
     ...
   `,
-imports: [NgOptimizedImage],
+  imports: [NgOptimizedImage],
 })
 </docs-code>
 

--- a/adev/src/content/tutorials/learn-angular/steps/12-enable-routing/README.md
+++ b/adev/src/content/tutorials/learn-angular/steps/12-enable-routing/README.md
@@ -39,7 +39,7 @@ import {provideRouter} from '@angular/router';
 import {routes} from './app.routes';
 
 export const appConfig: ApplicationConfig = {
-providers: [provideRouter(routes)],
+  providers: [provideRouter(routes)],
 };
 </docs-code>
 
@@ -55,15 +55,16 @@ Update the template for `AppComponent` by adding `<router-outlet />`
 import {RouterOutlet} from '@angular/router';
 
 @Component({
-...
-template: `     <nav>
+  ...
+  template: `
+    <nav>
       <a href="/">Home</a>
       |
       <a href="/user">User</a>
     </nav>
     <router-outlet />
   `,
-imports: [RouterOutlet],
+  imports: [RouterOutlet],
 })
 export class AppComponent {}
 </docs-code>

--- a/adev/src/content/tutorials/learn-angular/steps/13-define-a-route/README.md
+++ b/adev/src/content/tutorials/learn-angular/steps/13-define-a-route/README.md
@@ -21,7 +21,6 @@ To define a route, add a route object to the `routes` array in `app.routes.ts` t
 
 ```ts
 import {Routes} from '@angular/router';
-
 import {HomeComponent} from './home/home.component';
 
 export const routes: Routes = [
@@ -46,15 +45,14 @@ In `app.routes.ts`, add the `title` property to the default route (`path: ''`) a
 
 <docs-code language="ts" highlight="[8]">
 import {Routes} from '@angular/router';
-
 import {HomeComponent} from './home/home.component';
 
 export const routes: Routes = [
-{
-path: '',
-title: 'App Home Page',
-component: HomeComponent,
-},
+  {
+    path: '',
+    title: 'App Home Page',
+    component: HomeComponent,
+  },
 ];
 </docs-code>
 

--- a/adev/src/content/tutorials/learn-angular/steps/15-forms/README.md
+++ b/adev/src/content/tutorials/learn-angular/steps/15-forms/README.md
@@ -36,8 +36,8 @@ import {Component} from '@angular/core';
 import {FormsModule} from '@angular/forms';
 
 @Component({
-...
-imports: [FormsModule],
+  ...
+  imports: [FormsModule],
 })
 export class UserComponent {}
 </docs-code>

--- a/adev/src/content/tutorials/learn-angular/steps/16-form-control-values/README.md
+++ b/adev/src/content/tutorials/learn-angular/steps/16-form-control-values/README.md
@@ -51,9 +51,9 @@ export class UserComponent {
   favoriteFramework = '';
   ...
 
-showFramework() {
-alert(this.favoriteFramework);
-}
+  showFramework() {
+    alert(this.favoriteFramework);
+  }
 }
 </docs-code>
 

--- a/adev/src/content/tutorials/learn-angular/steps/19-creating-an-injectable-service/README.md
+++ b/adev/src/content/tutorials/learn-angular/steps/19-creating-an-injectable-service/README.md
@@ -14,10 +14,10 @@ To make a service eligible to be injected by the DI system use the `@Injectable`
 
 <docs-code language="ts" highlight="[1, 2, 3]">
 @Injectable({
-    providedIn: 'root'
+  providedIn: 'root'
 })
 class UserService {
-    // methods to retrieve and return data
+  // methods to retrieve and return data
 }
 </docs-code>
 

--- a/adev/src/content/tutorials/learn-angular/steps/20-inject-based-di/README.md
+++ b/adev/src/content/tutorials/learn-angular/steps/20-inject-based-di/README.md
@@ -13,7 +13,7 @@ It is often helpful to initialize class properties with values provided by the D
 <docs-code language="ts" highlight="[3]">
 @Component({...})
 class PetCareDashboardComponent {
-    petRosterService = inject(PetRosterService);
+  petRosterService = inject(PetRosterService);
 }
 </docs-code>
 

--- a/adev/src/content/tutorials/learn-angular/steps/22-pipes/README.md
+++ b/adev/src/content/tutorials/learn-angular/steps/22-pipes/README.md
@@ -14,12 +14,12 @@ To use a pipe in a template include it in an interpolated expression. Check out 
 import {UpperCasePipe} from '@angular/common';
 
 @Component({
-...
-template: `{{ loudMessage | uppercase }}`,
-imports: [UpperCasePipe],
+  ...
+  template: `{{ loudMessage | uppercase }}`,
+  imports: [UpperCasePipe],
 })
 class AppComponent {
-loudMessage = 'we think you are doing great!'
+  loudMessage = 'we think you are doing great!'
 }
 </docs-code>
 
@@ -41,8 +41,8 @@ Next, update `@Component()` decorator `imports` to include a reference to `Lower
 
 <docs-code language="ts" highlight="[3]">
 @Component({
-    ...
-    imports: [LowerCasePipe]
+  ...
+  imports: [LowerCasePipe]
 })
 </docs-code>
 

--- a/adev/src/content/tutorials/learn-angular/steps/23-pipes-format-data/README.md
+++ b/adev/src/content/tutorials/learn-angular/steps/23-pipes-format-data/README.md
@@ -26,8 +26,8 @@ In `app.component.ts`, update the template to include parameter for the `decimal
 
 <docs-code language="ts" highlight="[3]">
 template: `
-    ...
-    <li>Number with "decimal" {{ num | number:"3.2-2" }}</li>
+  ...
+  <li>Number with "decimal" {{ num | number:"3.2-2" }}</li>
 `
 </docs-code>
 
@@ -41,8 +41,8 @@ Now, update the template to use the `date` pipe.
 
 <docs-code language="ts" highlight="[3]">
 template: `
-    ...
-    <li>Date with "date" {{ birthday | date: 'medium' }}</li>
+  ...
+  <li>Date with "date" {{ birthday | date: 'medium' }}</li>
 `
 </docs-code>
 
@@ -56,8 +56,8 @@ For your last task, update the template to use the `currency` pipe.
 
 <docs-code language="ts" highlight="[3]">
 template: `
-    ...
-    <li>Currency with "currency" {{ cost | currency }}</li>
+  ...
+  <li>Currency with "currency" {{ cost | currency }}</li>
 `
 </docs-code>
 

--- a/adev/src/content/tutorials/learn-angular/steps/24-create-a-pipe/README.md
+++ b/adev/src/content/tutorials/learn-angular/steps/24-create-a-pipe/README.md
@@ -38,7 +38,7 @@ In `reverse.pipe.ts` add the `@Pipe` decorator to the `ReversePipe` class and pr
 
 ```ts
 @Pipe({
-    name: 'reverse'
+  name: 'reverse'
 })
 ```
 
@@ -50,16 +50,15 @@ Now the `ReversePipe` class is a pipe. Update the `transform` function to add th
 
 <docs-code language="ts" highlight="[3,4,5,6,7,8,9]">
 export class ReversePipe implements PipeTransform {
-    transform(value: string): string {
-        let reverse = '';
+  transform(value: string): string {
+    let reverse = '';
 
-        for (let i = value.length - 1; i >= 0; i--) {
-            reverse += value[i];
-        }
-
-        return reverse;
+    for (let i = value.length - 1; i >= 0; i--) {
+      reverse += value[i];
     }
 
+    return reverse;
+  }
 }
 </docs-code>
 
@@ -70,9 +69,9 @@ With the pipe logic implemented, the final step is to use it in the template. In
 
 <docs-code language="angular-ts" highlight="[3,4]">
 @Component({
-    ...
-    template: `Reverse Machine: {{ word | reverse }}`
-    imports: [ReversePipe]
+  ...
+  template: `Reverse Machine: {{ word | reverse }}`
+  imports: [ReversePipe]
 })
 </docs-code>
 

--- a/adev/src/content/tutorials/learn-angular/steps/6-property-binding/README.md
+++ b/adev/src/content/tutorials/learn-angular/steps/6-property-binding/README.md
@@ -25,7 +25,7 @@ Update the code in `app.component.ts` by adding a property to the `AppComponent`
 
 <docs-code highlight="[2]">
 export class AppComponent {
-    isEditable = true;
+  isEditable = true;
 }
 </docs-code>
 </docs-step>
@@ -35,8 +35,8 @@ Next, bind the `contentEditable` attribute of the `div` to the `isEditable` prop
 
 <docs-code highlight="[3]" language="angular-ts">
 @Component({
-    ...
-    template: `<div [contentEditable]="isEditable"></div>`,
+  ...
+  template: `<div [contentEditable]="isEditable"></div>`,
 })
 </docs-code>
 </docs-step>

--- a/adev/src/content/tutorials/learn-angular/steps/7-event-handling/README.md
+++ b/adev/src/content/tutorials/learn-angular/steps/7-event-handling/README.md
@@ -12,13 +12,13 @@ In Angular you bind to events with the parentheses syntax `()`. On a given eleme
 
 ```angular-ts
 @Component({
-    ...
-    template: `<button (click)="greet()">`
+  ...
+  template: `<button (click)="greet()">`
 })
 class AppComponent {
-    greet() {
-        console.log('Hello, there 👋');
-    }
+  greet() {
+    console.log('Hello, there 👋');
+  }
 }
 ```
 
@@ -33,7 +33,7 @@ Add the `onMouseOver` event handler function in the `AppComponent` class. Use th
 
 ```ts
 onMouseOver() {
-    this.message = 'Way to go 🚀';
+  this.message = 'Way to go 🚀';
 }
 ```
 

--- a/adev/src/content/tutorials/learn-angular/steps/9-output/README.md
+++ b/adev/src/content/tutorials/learn-angular/steps/9-output/README.md
@@ -15,7 +15,7 @@ To create the communication path from child to parent components, use the `@Outp
 <docs-code header="child.component.ts" language="ts">
 @Component({...})
 class ChildComponent {
-    @Output() incrementCountEvent = new EventEmitter<number>();
+  @Output() incrementCountEvent = new EventEmitter<number>();
 }
 </docs-code>
 
@@ -23,13 +23,12 @@ Now the component can generate events that can be listened to by the parent comp
 
 <docs-code header="child.component.ts" language="ts">
 class ChildComponent {
-    ...
+  ...
 
-    onClick() {
-        this.count++;
-        this.incrementCountEvent.emit(this.count);
-    }
-
+  onClick() {
+    this.count++;
+    this.incrementCountEvent.emit(this.count);
+  }
 }
 </docs-code>
 


### PR DESCRIPTION
This fixes multiple cases of wrong `visibleLines` values on `<docs-code>`  elements within the First-App tutorial pages on **v19**.angular.dev site. 

In many files the line numbers are too high by 1, which is a result of shortening many files by a [code refactoring in the past](https://github.com/angular/angular/pull/58660), without updating docs to match that change. The issue was introduced on Nov 14 2024, hence it occurs in versions 19 and 20 only.

> This PR is partially reflecting fixes for the same issue 
> that were merged into `main` with https://github.com/angular/angular/pull/61909

Additionally, some minor improvements to indentation, descriptions and explanations were also added. 

This PR fixes issues found within almost all of the 14 steps of the First App tutorial, and also some minor indentation corrections within the lessons of the Learn Angular tutorial.

**  ([source branch got squashed in the meantime](https://github.com/sEver/angular/tree/sEvere-tutorial-quality-check-for-v19)) **

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [x] angular.dev application / infrastructure changes
- [x] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
